### PR TITLE
Add login dialog and update navigation

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,23 @@
 import { render, screen } from '@testing-library/react';
+
+jest.mock('./lib/firebase', () => ({
+  signInWithGoogle: jest.fn(),
+  signInWithGitHub: jest.fn(),
+  logOut: jest.fn(),
+  auth: {}
+}));
+
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: (_auth, callback) => {
+    callback(null);
+    return () => {};
+  }
+}));
+
 import App from './App';
 
-test('renders learn react link', () => {
+test('shows login button when not authenticated', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const buttonElement = screen.getByText(/登录/);
+  expect(buttonElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from './components/ui/card';
+import { Dialog } from './components/ui/dialog';
 import {
   CheckCircle,
   ChevronRight,
@@ -73,6 +74,7 @@ const App: React.FC = () => {
   const [translatedQuestions, setTranslatedQuestions] = useState<{ [key: number]: Question[] }>(rawQuestions);
   /** Authentication status (true if logged in, false otherwise). */
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [showLogin, setShowLogin] = useState(false);
   /** Controls the visibility of the Risk Assessment modal/component. */
   const [isRiskAssessmentOpen, setIsRiskAssessmentOpen] = useState(false);
   /** Stores the result from the completed risk assessment. */
@@ -97,6 +99,7 @@ const App: React.FC = () => {
           riskTolerance: 'steady',
           preferredStrategies: [],
         });
+        setShowLogin(false);
       } else {
         setUser(null);
       }
@@ -332,11 +335,59 @@ const App: React.FC = () => {
     localStorage.removeItem('investmentDecisions');
   };
 
-  // Render different content based on application state
-  if (!isLoggedIn) {
-    // Render login/registration page (simplified for this example)
-    return (
-      <div className="flex items-center justify-center h-screen bg-gray-100 dark:bg-gray-900">
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50 dark:bg-gray-900">
+      {/* Top Navigation Bar */}
+      <nav className="bg-white dark:bg-gray-800 shadow-md py-4">
+        <div className="container mx-auto flex justify-between items-center px-4">
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-6 w-6 text-blue-500 dark:text-blue-400" />
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+              {translations[language].appName}
+            </h1>
+          </div>
+          <div className="flex items-center gap-4">
+            {isLoggedIn && (
+              <span className="text-gray-600 dark:text-gray-300">
+                {translations[language].welcome}, {user?.name}
+              </span>
+            )}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+              className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+              title={theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+            >
+              {theme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setLanguage(language === 'en' ? 'zh' : 'en')}
+              className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+              title={language === 'en' ? '中文' : 'English'}
+            >
+              <Globe className="h-5 w-5" />
+            </Button>
+            {isLoggedIn ? (
+              <Button
+                variant="ghost"
+                onClick={handleLogout}
+                className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+              >
+                <LogOut className="h-5 w-5" />
+              </Button>
+            ) : (
+              <Button onClick={() => setShowLogin(true)}>
+                {translations[language].login}
+              </Button>
+            )}
+          </div>
+        </div>
+      </nav>
+
+      <Dialog open={showLogin} onOpenChange={setShowLogin}>
         <Card className="w-[350px] shadow-lg dark:bg-gray-900 dark:border-gray-700">
           <CardHeader>
             <CardTitle className="text-gray-900 dark:text-white">
@@ -364,53 +415,7 @@ const App: React.FC = () => {
             </div>
           </CardContent>
         </Card>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col min-h-screen bg-gray-50 dark:bg-gray-900">
-      {/* Top Navigation Bar */}
-      <nav className="bg-white dark:bg-gray-800 shadow-md py-4">
-        <div className="container mx-auto flex justify-between items-center px-4">
-          <div className="flex items-center gap-2">
-            <BookOpen className="h-6 w-6 text-blue-500 dark:text-blue-400" />
-            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
-              {translations[language].appName}
-            </h1>
-          </div>
-          <div className="flex items-center gap-4">
-            <span className="text-gray-600 dark:text-gray-300">
-              {translations[language].welcome}, {user?.name}
-            </span>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-              className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
-              title={theme === 'light' ? 'Dark Mode' : 'Light Mode'}
-            >
-              {theme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setLanguage(language === 'en' ? 'zh' : 'en')}
-              className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
-              title={language === 'en' ? '中文' : 'English'}
-            >
-              <Globe className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="ghost"
-              onClick={handleLogout}
-              className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
-            >
-              <LogOut className="h-5 w-5" />
-            </Button>
-          </div>
-        </div>
-      </nav>
+      </Dialog>
 
       {/* Main Content Area */}
       <div className="container mx-auto px-4 py-8">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -379,7 +379,7 @@ const App: React.FC = () => {
                 <LogOut className="h-5 w-5" />
               </Button>
             ) : (
-              <Button onClick={() => setShowLogin(true)}>
+              <Button onClick={() => setShowLogin(true)} data-testid="login-button">
                 {translations[language].login}
               </Button>
             )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export const Dialog: React.FC<DialogProps> = ({ open, onOpenChange, children }) => {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={() => onOpenChange(false)}
+    >
+      <div onClick={(e) => e.stopPropagation()}>{children}</div>
+    </div>
+  );
+};
+

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 interface DialogProps {
   open: boolean;
@@ -7,14 +7,31 @@ interface DialogProps {
 }
 
 export const Dialog: React.FC<DialogProps> = ({ open, onOpenChange, children }) => {
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onOpenChange(false);
+      }
+    };
+
+    if (open) {
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open, onOpenChange]);
+
   if (!open) return null;
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={() => onOpenChange(false)}
+      role="dialog"
+      aria-modal="true"
     >
       <div onClick={(e) => e.stopPropagation()}>{children}</div>
     </div>
   );
 };
-

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,21 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+// @ts-ignore
+global.TextDecoder = TextDecoder;
+import { ReadableStream } from 'stream/web';
+// @ts-ignore
+global.ReadableStream = ReadableStream;
+
+window.matchMedia = window.matchMedia || function () {
+  return {
+    matches: false,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {},
+  };
+};


### PR DESCRIPTION
## Summary
- Replace full-screen login gate with dialog triggered from navigation
- Always render navigation; show login or logout depending on auth state
- Add simple Dialog component and accompanying tests

## Testing
- `npm test -- --watchAll=false`
- `npm run build`
- `BROWSER=none npm start`


------
https://chatgpt.com/codex/tasks/task_e_689a40cf69a88332ac0a37771c56ae1d