### PR TITLE
Add email/password auth option

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 jest.mock('./lib/firebase', () => ({
   signInWithGoogle: jest.fn(),
   signInWithGitHub: jest.fn(),
+  registerWithEmail: jest.fn(),
+  signInWithEmail: jest.fn(),
   logOut: jest.fn(),
   auth: {}
 }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import React, { useState, useEffect, useCallback } from 'react';
 import { Button } from './components/ui/button';
+import { Input } from './components/ui/input';
 import {
   Card,
   CardContent,
@@ -30,7 +31,14 @@ import { InvestmentCheckpoint, rawQuestions, questionTranslations, optionToTrans
 import { InvestmentEvaluation } from './components/investment-evaluation';
 import { InvestmentDecision, RiskAssessmentResult, UserProfile, Question, EvaluationResult } from './types';
 import { translations } from './constants/index';
-import { signInWithGoogle, signInWithGitHub, logOut, auth } from './lib/firebase';
+import {
+  signInWithGoogle,
+  signInWithGitHub,
+  registerWithEmail,
+  signInWithEmail,
+  logOut,
+  auth,
+} from './lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 
 const deepSeekApiKey = process.env.REACT_APP_DEEPSEEK_API_KEY || ''; // 或者 process.env.VITE_DEEPSEEK_API_KEY
@@ -75,6 +83,8 @@ const App: React.FC = () => {
   /** Authentication status (true if logged in, false otherwise). */
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   /** Controls the visibility of the Risk Assessment modal/component. */
   const [isRiskAssessmentOpen, setIsRiskAssessmentOpen] = useState(false);
   /** Stores the result from the completed risk assessment. */
@@ -399,6 +409,34 @@ const App: React.FC = () => {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
+              <Input
+                type="email"
+                placeholder={translations[language].email}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="text-gray-900 dark:text-white dark:bg-gray-700"
+              />
+              <Input
+                type="password"
+                placeholder={translations[language].password}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="text-gray-900 dark:text-white dark:bg-gray-700"
+              />
+              <div className="flex gap-2">
+                <Button
+                  className="w-full bg-green-500 hover:bg-green-600 text-white dark:bg-green-700 dark:hover:bg-green-800"
+                  onClick={() => registerWithEmail(email, password)}
+                >
+                  {translations[language].register}
+                </Button>
+                <Button
+                  className="w-full bg-blue-500 hover:bg-blue-600 text-white dark:bg-blue-700 dark:hover:bg-blue-800"
+                  onClick={() => signInWithEmail(email, password)}
+                >
+                  {translations[language].login}
+                </Button>
+              </div>
               <Button
                 className="w-full bg-blue-500 hover:bg-blue-600 text-white dark:bg-blue-700 dark:hover:bg-blue-800"
                 onClick={signInWithGoogle}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -5,6 +5,8 @@ import {
   GithubAuthProvider,
   signInWithPopup,
   signOut,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
 } from 'firebase/auth';
 
 const firebaseConfig = {
@@ -48,5 +50,25 @@ export const logOut = async () => {
     await signOut(auth);
   } catch (error) {
     console.error("Error during sign-out:", error);
+  }
+};
+
+export const registerWithEmail = async (email: string, password: string) => {
+  try {
+    const result = await createUserWithEmailAndPassword(auth, email, password);
+    return result.user;
+  } catch (error) {
+    console.error('Error during email registration:', error);
+    return null;
+  }
+};
+
+export const signInWithEmail = async (email: string, password: string) => {
+  try {
+    const result = await signInWithEmailAndPassword(auth, email, password);
+    return result.user;
+  } catch (error) {
+    console.error('Error during email sign-in:', error);
+    return null;
   }
 };


### PR DESCRIPTION
## Summary
- add Firebase helpers for email/password registration and login
- integrate email login/registration form alongside social providers
- adjust tests to mock new auth helpers

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689a9f4db0408332b54bde6f658e7485