### PR TITLE
feat: add unified sign-up or sign-in helper

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { translations } from './constants/index';
 
-
 jest.mock('./lib/firebase', () => ({
   signInWithGoogle: jest.fn(),
   signInWithGitHub: jest.fn(),
@@ -26,9 +25,6 @@ test('shows login button and reminder when not authenticated', () => {
   const buttonElement = screen.getByTestId('login-button');
   expect(buttonElement).toBeInTheDocument();
   const reminder = screen.getByText(
-    
-    
-    
     .zh.loginReminder);
   expect(reminder).toBeInTheDocument();
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,11 @@
 import { render, screen } from '@testing-library/react';
+import { translations } from './constants/index';
 
 jest.mock('./lib/firebase', () => ({
   signInWithGoogle: jest.fn(),
   signInWithGitHub: jest.fn(),
   registerWithEmail: jest.fn(),
+  signUpOrSignIn: jest.fn(),
   signInWithEmail: jest.fn(),
   logOut: jest.fn(),
   auth: {}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ import { translations } from './constants/index';
 import {
   signInWithGoogle,
   signInWithGitHub,
-  registerWithEmail,
+  signUpOrSignIn,
   signInWithEmail,
   logOut,
   auth,
@@ -445,7 +445,7 @@ const App: React.FC = () => {
               <div className="flex gap-2">
                 <Button
                   className="w-full bg-green-500 hover:bg-green-600 text-white dark:bg-green-700 dark:hover:bg-green-800"
-                  onClick={() => handleAuthAction(registerWithEmail)}
+                  onClick={() => handleAuthAction(signUpOrSignIn)}
                   disabled={isLoading}
                 >
                   {translations[language].register}


### PR DESCRIPTION
## Summary
- add `signUpOrSignIn` to Firebase auth utilities
- use `signUpOrSignIn` for email registration flow in `App`
- adjust tests for new helper

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689b22da73308332aa21d91c80db52c0