### PR TITLE
feat: add Firebase storage helpers

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -20,7 +20,7 @@ const firebaseConfig = {
   measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
 };
 
-const app = initializeApp(firebaseConfig);
+export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 
 export const signInWithGoogle = async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,30 @@
+import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { app } from './firebase';
+
+export const storage = getStorage(app);
+
+export async function uploadJson(path: string, data: unknown): Promise<void> {
+  try {
+    const storageRef = ref(storage, path);
+    const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+    await uploadBytes(storageRef, blob);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to upload JSON to "${path}": ${message}`);
+  }
+}
+
+export async function downloadJson<T = unknown>(path: string): Promise<T> {
+  try {
+    const storageRef = ref(storage, path);
+    const url = await getDownloadURL(storageRef);
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP error ${response.status}`);
+    }
+    return (await response.json()) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to download JSON from "${path}": ${message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- expose Firebase `app` for reuse
- add `storage` module with JSON upload and download helpers

## Testing
- `CI=true npm test` *(fails: Identifier 'translations' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_689b3540606083329f0fda17bdbd0745