### PR TITLE
Persist risk assessment results and load on login

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,31 +1,27 @@
 import { render, screen } from '@testing-library/react';
-import { translations } from './constants/index';
+import App from './App';
+import { translations } from './constants';
 
 jest.mock('./lib/firebase', () => ({
   signInWithGoogle: jest.fn(),
   signInWithGitHub: jest.fn(),
-  registerWithEmail: jest.fn(),
   signUpOrSignIn: jest.fn(),
   signInWithEmail: jest.fn(),
   logOut: jest.fn(),
-  auth: {}
+  auth: {},
 }));
 
 jest.mock('firebase/auth', () => ({
   onAuthStateChanged: (_auth, callback) => {
     callback(null);
     return () => {};
-  }
+  },
 }));
-
-import App from './App';
-import { translations } from './constants';
 
 test('shows login button and reminder when not authenticated', () => {
   render(<App />);
   const buttonElement = screen.getByTestId('login-button');
   expect(buttonElement).toBeInTheDocument();
-  const reminder = screen.getByText(
-    .zh.loginReminder);
+  const reminder = screen.getByText(translations.zh.loginReminder);
   expect(reminder).toBeInTheDocument();
 });

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,79 @@
+import { getApp, getApps } from 'firebase/app';
+import {
+  getFirestore,
+  doc,
+  setDoc,
+  getDoc,
+  collection,
+  query,
+  orderBy,
+  limit,
+  getDocs,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { RiskAssessmentResult, RiskProfileType } from '../types';
+
+const getDb = () => {
+  if (!getApps().length) {
+    return null;
+  }
+  return getFirestore(getApp());
+};
+
+/**
+ * Save a risk assessment result for a user under
+ * `riskAssessments/{uid}/assessments/{assessmentId}`.
+ */
+export const saveRiskAssessment = async (
+  uid: string,
+  assessmentId: string,
+  result: RiskAssessmentResult
+): Promise<void> => {
+  const db = getDb();
+  if (!db) return;
+  const ref = doc(db, 'riskAssessments', uid, 'assessments', assessmentId);
+  await setDoc(ref, { ...result, createdAt: serverTimestamp() });
+};
+
+/**
+ * Load a specific risk assessment result for a user.
+ */
+export const loadRiskAssessment = async (
+  uid: string,
+  assessmentId: string
+): Promise<RiskAssessmentResult | null> => {
+  const db = getDb();
+  if (!db) return null;
+  const ref = doc(db, 'riskAssessments', uid, 'assessments', assessmentId);
+  const snap = await getDoc(ref);
+  return snap.exists() ? (snap.data() as RiskAssessmentResult) : null;
+};
+
+/**
+ * Fetch the most recent risk assessment result for a user.
+ */
+export const loadLatestRiskAssessment = async (
+  uid: string
+): Promise<RiskAssessmentResult | null> => {
+  const db = getDb();
+  if (!db) return null;
+  const colRef = collection(db, 'riskAssessments', uid, 'assessments');
+  const q = query(colRef, orderBy('createdAt', 'desc'), limit(1));
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) return null;
+  return snapshot.docs[0].data() as RiskAssessmentResult;
+};
+
+/**
+ * Update a user's risk tolerance in their profile document.
+ */
+export const updateUserRiskTolerance = async (
+  uid: string,
+  riskTolerance: RiskProfileType
+): Promise<void> => {
+  const db = getDb();
+  if (!db) return;
+  const userRef = doc(db, 'users', uid);
+  await setDoc(userRef, { riskTolerance }, { merge: true });
+};
+


### PR DESCRIPTION
## Summary
- add Firestore helpers to store and fetch user risk assessments and update profile risk tolerance
- save risk assessment results on completion and pull latest result on login to initialize the app

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689b391dc6108332b691834b35912661