### PR TITLE
feat: add user profile storage helpers

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { translations } from './constants/index';
+import App from './App';
+import { translations } from './constants';
 
 jest.mock('./lib/firebase', () => ({
   signInWithGoogle: jest.fn(),
@@ -8,24 +9,26 @@ jest.mock('./lib/firebase', () => ({
   signUpOrSignIn: jest.fn(),
   signInWithEmail: jest.fn(),
   logOut: jest.fn(),
-  auth: {}
+  auth: {},
+}));
+
+jest.mock('./lib/storage', () => ({
+  readUserProfile: jest.fn(),
+  writeUserProfile: jest.fn(),
+  updateUserProfile: jest.fn(),
 }));
 
 jest.mock('firebase/auth', () => ({
   onAuthStateChanged: (_auth, callback) => {
     callback(null);
     return () => {};
-  }
+  },
 }));
-
-import App from './App';
-import { translations } from './constants';
 
 test('shows login button and reminder when not authenticated', () => {
   render(<App />);
   const buttonElement = screen.getByTestId('login-button');
   expect(buttonElement).toBeInTheDocument();
-  const reminder = screen.getByText(
-    .zh.loginReminder);
+  const reminder = screen.getByText(translations.zh.loginReminder);
   expect(reminder).toBeInTheDocument();
 });

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -20,7 +20,7 @@ const firebaseConfig = {
   measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
 };
 
-const app = initializeApp(firebaseConfig);
+export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 
 export const signInWithGoogle = async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,42 @@
+import { getStorage, ref, getDownloadURL, uploadString } from 'firebase/storage';
+import { app } from './firebase';
+import { UserProfile } from '../types';
+
+const storage = getStorage(app);
+
+const profileRef = (uid: string) => ref(storage, `userProfiles/${uid}/profile.json`);
+
+export const readUserProfile = async (uid: string): Promise<UserProfile | null> => {
+  try {
+    const url = await getDownloadURL(profileRef(uid));
+    const resp = await fetch(url);
+    return (await resp.json()) as UserProfile;
+  } catch (error: any) {
+    if (error?.code === 'storage/object-not-found') {
+      return null;
+    }
+    console.error('Error reading user profile:', error);
+    throw error;
+  }
+};
+
+export const writeUserProfile = async (uid: string, profile: UserProfile): Promise<void> => {
+  await uploadString(profileRef(uid), JSON.stringify(profile), 'raw', {
+    contentType: 'application/json',
+  });
+};
+
+export const updateUserProfile = async (
+  uid: string,
+  updates: Partial<UserProfile>
+): Promise<UserProfile> => {
+  const current = (await readUserProfile(uid)) || {
+    id: uid,
+    name: '',
+    riskTolerance: 'steady',
+    preferredStrategies: [],
+  };
+  const updated = { ...current, ...updates } as UserProfile;
+  await writeUserProfile(uid, updated);
+  return updated;
+};


### PR DESCRIPTION
## Summary
- add Firebase Storage utilities for user profiles
- load and persist user profile on auth state changes
- store risk tolerance updates in user profile

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b391ebb6c83328f732c2f5c607eca